### PR TITLE
feat: add global notification bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import { AuthProvider, AuthContext } from "./context/AuthContext";
 import { ThemeProviderWrapper } from "./context/ThemeContext";
 import { NotificationProvider } from "./context/NotificationContext";
 import { SettingsProvider } from "./context/SettingsContext";
+import { AppProvider } from "./contexts/AppContext";
+import NotificationBar from "./components/notifications/NotificationBar";
 import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import TeamsPage from "./pages/TeamsPage";
@@ -65,6 +67,8 @@ function AppLayout() {
           transition: "padding-left 0.s ease-in-out",
         }}
       >
+        {/* Global notification bar */}
+        <NotificationBar />
         <Routes>
           {/* ✅ Redirect to /dashboard if authenticated */}
           <Route path="/" element={isAuthenticated ? <Navigate to="/dashboard" /> : <Login />} />
@@ -108,7 +112,9 @@ export default function App() {
           <AuthProvider>
             <SettingsProvider>
               <NotificationProvider>
-                <AppLayout />
+                <AppProvider>
+                  <AppLayout />
+                </AppProvider>
               </NotificationProvider>
             </SettingsProvider>
           </AuthProvider>

--- a/src/components/notifications/NotificationBar.tsx
+++ b/src/components/notifications/NotificationBar.tsx
@@ -1,27 +1,57 @@
 // src/components/notifications/NotificationBar.tsx
-import React from 'react';
-import { Snackbar, Alert, Slide, SlideProps } from '@mui/material';
+import React, { useEffect, useRef, useState } from 'react';
+import { Snackbar, Alert, Slide, SlideProps, AlertColor } from '@mui/material';
 import { useApp } from '../../contexts/AppContext';
+import { useNotifications, NotificationWithTargets } from '../../context/NotificationContext';
 
 const SlideTransition = (props: SlideProps) => {
   return <Slide {...props} direction="down" />;
 };
 
 const NotificationBar: React.FC = () => {
-  const { notifications, removeNotification } = useApp();
+  const { notifications: appNotifications, removeNotification } = useApp();
+  const { notifications: backendNotifications } = useNotifications();
+
+  const [visibleBackend, setVisibleBackend] = useState<NotificationWithTargets[]>([]);
+  const shownBackendIds = useRef<Set<number>>(new Set());
+
+  useEffect(() => {
+    const newNotifs = backendNotifications.filter(
+      n => !shownBackendIds.current.has(n.notification.id)
+    );
+    if (newNotifs.length > 0) {
+      newNotifs.forEach(n => shownBackendIds.current.add(n.notification.id));
+      setVisibleBackend(prev => [...prev, ...newNotifs]);
+    }
+  }, [backendNotifications]);
+
+  const handleBackendClose = (id: number) => {
+    setVisibleBackend(prev => prev.filter(n => n.notification.id !== id));
+  };
+
+  const mapSeverity = (type: string): AlertColor => {
+    switch (type) {
+      case 'review_request':
+        return 'warning';
+      case 'system_announcement':
+        return 'error';
+      default:
+        return 'info';
+    }
+  };
 
   return (
     <>
-      {notifications.map((notification, index) => (
+      {appNotifications.map((notification, index) => (
         <Snackbar
           key={notification.id}
-          open={true}
+          open
           autoHideDuration={notification.duration}
           onClose={() => removeNotification(notification.id)}
           TransitionComponent={SlideTransition}
           anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
           sx={{
-            mt: index * 7, // Stack multiple notifications
+            mt: index * 7,
             zIndex: 1400 + index,
           }}
         >
@@ -36,6 +66,36 @@ const NotificationBar: React.FC = () => {
               <>
                 <br />
                 {notification.message}
+              </>
+            )}
+          </Alert>
+        </Snackbar>
+      ))}
+
+      {visibleBackend.map((notif, index) => (
+        <Snackbar
+          key={`backend-${notif.notification.id}`}
+          open
+          autoHideDuration={6000}
+          onClose={() => handleBackendClose(notif.notification.id)}
+          TransitionComponent={SlideTransition}
+          anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+          sx={{
+            mt: (appNotifications.length + index) * 7,
+            zIndex: 1400 + appNotifications.length + index,
+          }}
+        >
+          <Alert
+            onClose={() => handleBackendClose(notif.notification.id)}
+            severity={mapSeverity(notif.notification.type)}
+            variant="filled"
+            sx={{ width: '100%' }}
+          >
+            <strong>{notif.notification.title}</strong>
+            {notif.notification.body && (
+              <>
+                <br />
+                {notif.notification.body}
               </>
             )}
           </Alert>


### PR DESCRIPTION
## Summary
- wrap app layout with AppProvider and surface NotificationBar for user feedback
- extend NotificationBar to display both app-level and backend notifications without repeats

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68993c4606dc83269732afada06836b0